### PR TITLE
Initial work to get docker image created and uploaded

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,54 @@
+name: Build Docker Image
+
+on:
+    pull_request:
+        types:
+            - synchronize
+            - opened
+            - ready_for_review
+            - reopened
+        paths-ignore:
+            - 'LICENSE'
+            - '*.md'
+    push:
+        branches:
+            - 'main'
+
+jobs:
+    build-image:
+        runs-on: ubuntu:latest
+        env:
+            LATEST_TAG: sethicis/snowsql-cli:latest
+            IMAGE_TAGS: 'sethicis/snowsql-cli:rockylinux-9,sethicis/snowsql-cli:0.0.1'
+        steps:
+            - 
+                name: Login to GitHub Container Registry
+                uses: docker/login-action@v3
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -
+                name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v3
+            -
+                name: Set up QEMU
+                uses: docker/setup-qemu-action@v3
+            - 
+                name: Build and export to Docker
+                uses: docker/build-push-action@v6
+                with:
+                    load: true
+                    tags: ${{ env.LATEST_TAG }}
+            - 
+                name: Test
+                run: |
+                    docker run --rm sethicis/snowsql-cli:latest
+            - 
+                if: ${{ github.event_name == 'push' }}
+                name: Build and push
+                uses: docker/build-push-action@v6
+                with:
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{ env.LATEST_TAG }},${{ env.IMAGE_TAGS }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
     build-image:
-        runs-on: ubuntu:latest
+        runs-on: ubuntu-latest
         env:
             LATEST_TAG: sethicis/snowsql-cli:latest
             IMAGE_TAGS: 'sethicis/snowsql-cli:rockylinux-9,sethicis/snowsql-cli:0.0.1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rockylinux:9
+
+RUN yum install -y https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowflake-snowsql-1.4.0-1.x86_64.rpm
+RUN useradd -ms /bin/bash abc
+USER abc
+
+ENTRYPOINT ['snowsql', '-v']

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
 FROM rockylinux:9
 
-RUN yum install -y https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowflake-snowsql-1.4.0-1.x86_64.rpm
+ARG TARGETARCH
+ARG BUILDPLATFORM
+
+RUN echo "Building for $TARGETARCH"
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        echo "Building for ARM64"; \
+        yum install -y https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_aarch64/snowflake-snowsql-1.4.0-1.aarch64.rpm; \
+    else \
+        echo "Building for AMD64"; \
+        yum install -y https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowflake-snowsql-1.4.0-1.x86_64.rpm; \
+    fi
 RUN useradd -ms /bin/bash abc
 USER abc
 
-ENTRYPOINT ['snowsql', '-v']
+ENTRYPOINT ["snowsql", "-v"]


### PR DESCRIPTION
This pull request introduces a new Docker-based workflow for building, testing, and pushing a Docker image for the `snowsql-cli` tool. It also includes the creation of a `Dockerfile` to define the image. Below are the key changes grouped by theme:

### CI/CD Workflow for Docker Image:

* Added a GitHub Actions workflow (`.github/workflows/build-docker-image.yml`) to automate the process of building, testing, and pushing the Docker image. The workflow triggers on specific pull request events and pushes to the `main` branch. It uses Docker actions for login, setup, and multi-platform builds.

### Docker Image Definition:

* Created a `Dockerfile` to build a Docker image based on `rockylinux:9`. The image installs the SnowSQL CLI tool, adds a non-root user (`abc`), and sets the default entry point as the `snowsql` command with the `-v` flag to display the version.