### PR TITLE
Added mysql and psql to the base image to make testing network access easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM rockylinux:9
 ARG TARGETARCH
 ARG BUILDPLATFORM
 
+RUN dnf install mysql postgresql -y
 RUN echo "Building for $TARGETARCH"
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         echo "Building for ARM64"; \


### PR DESCRIPTION
## Changes

Added psql and mysql to the base image so that they can be used in kubernetes network reachability tests.